### PR TITLE
docs: improve PCBWay manufacturing instructions

### DIFF
--- a/src/assembly/crimpdeq/pcb.md
+++ b/src/assembly/crimpdeq/pcb.md
@@ -16,13 +16,32 @@ Revision 1 has been tested and works as expected, but there is still room for im
 You can find the schematic, layout, and production files in the repository [latest GitHub release](https://github.com/crimpdeq/crimpdeq-pcb/releases/latest).
 
 ## How to Manufacture
-1. Download the production files from the [GitHub release](https://github.com/crimpdeq/crimpdeq-pcb/releases/latest).
-   - The release includes the files typically needed by PCB manufacturers:
-     - `gerber.zip`: PCB fabrication files
-     - `bom.csv`: bill of materials for assembly
-     - `positions.csv`: component placement file for assembly
+There are two ways to order this PCB:
 
-2. Submit the order and wait for the manufacturer review.
-   - Some manufacturers may contact you with questions about substitutions, assembly notes, or file interpretation.
+1. **Using the PCBWay Project page** — recommended, since it already includes the latest uploaded production files.
+2. **Placing your own PCBWay order** using the production files from the repository releases.
 
-> ⚠️ **Note**: If the manufacturer comes back with questions or suggestions and you are unsure how to answer, feel free to contact me at sergio.gasquez@gmail.com.
+### Using PCBWay Projects
+1. Open the PCBWay Project page using the button below.
+
+   <a href="https://www.pcbway.com/project/shareproject/Crimpdeq_A_portable_digital_force_sensor_for_climbers_81ff4ae8.html"><img src="https://www.pcbway.com/project/img/images/frompcbway-1220.png" alt="PCB from PCBWay" /></a>
+
+2. On the right panel, select **PCB+Assembly** and click **Add to Cart**.
+3. Enter the desired quantity and click **Calculate**.
+
+   > ⚠️ **Note**: PCBWay shows two quantity fields. One is the number of PCBs to manufacture, and the other is the number of boards to assemble with components. The minimum PCB quantity is usually 5.
+
+4. Choose your shipping country and shipping method.
+5. Click **Save to Cart** to continue with checkout.
+
+### Placing Your Own Order on PCBWay
+1. Download the production files from the [latest GitHub release](https://github.com/crimpdeq/crimpdeq-pcb/releases/latest).
+2. Use the included files when creating your PCBWay order:
+   - `gerber.zip`: PCB fabrication files
+   - `bom.csv`: bill of materials for assembly
+   - `positions.csv`: component placement file for assembly
+3. Submit the order and wait for the manufacturer review.
+
+   - The manufacturer may contact you with questions about substitutions, assembly notes, or file interpretation.
+
+> ⚠️ **Note**: If the manufacturer contacts you with questions or suggestions and you are unsure how to answer, feel free to email me at sergio.gasquez@gmail.com.


### PR DESCRIPTION
## Summary
- add a recommended PCBWay Project ordering flow
- keep manual PCBWay ordering instructions with the required production files
- clarify quantity selection and manufacturer follow-up guidance

## Testing
- not run (documentation change)